### PR TITLE
video methods testing

### DIFF
--- a/tests/test_channel_methods.py
+++ b/tests/test_channel_methods.py
@@ -20,5 +20,7 @@ class TestVideo(unittest.TestCase):
 
     def test_upload_playlist_id(self):
         self.assertEqual(get_upload_playlist_id(self.channel_id), 'UU3XTzVzaHQEd30rQbuvCtTQ')
+        
 
-    
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_methods.py
+++ b/tests/test_video_methods.py
@@ -17,6 +17,7 @@ class TestVideo(unittest.TestCase):
         cls.channel_id = 'UC8-Th83bH_thdKZDJCrn88g'
         cls.vid_publish = datetime.datetime(2018, 11, 28, 10, 0, 3)
         cls.search_term = 'John Oliver'
+        cls.list_of_videos = ['ximgPmJ9A5s','RdjRMDADpcg']
         
     #written by Megan Brown on 11/30/2018
     def test_video_metadata_valid(self):
@@ -25,7 +26,8 @@ class TestVideo(unittest.TestCase):
         self.assertEqual(resp['video_id'], self.video_id)
         self.assertEqual(resp['channel_id'], self.channel_id)
         self.assertEqual(resp['video_publish_date'], self.vid_publish)
-        
+    
+    #written by Megan Brown on 11/30/2018
     def test_search_for_video_method(self):
         resp = self.yt.search(self.search_term)
         
@@ -33,7 +35,25 @@ class TestVideo(unittest.TestCase):
             self.assertTrue('video_id' in list(item.keys()))
             self.assertTrue('video_title' in list(item.keys()))
             self.assertTrue('channel_title' in list(item.keys()))
-
+            
+    #written by Megan Brown on 11/30/2018
+    def test_video_metadata_with_list_input(self):
+        resp = self.yt.get_video_metadata(self.list_of_videos)
+        
+        self.assertTrue(len(resp) == 2)
+        
+        for item in resp:
+            self.assertTrue('video_id' in list(item.keys()))
+            self.assertTrue('video_title' in list(item.keys()))
+            self.assertTrue('channel_title' in list(item.keys()))
+    
+    #written by Megan Brown on 11/20/2018
+    def test_video_metadata_with_invalid_list(self):
+        invalid_list_of_videos = self.list_of_videos
+        invalid_list_of_videos.append('xxxxxxxx')
+        
+        resp = self.yt.get_video_metadata(invalid_list_of_videos)
+        self.assertTrue(len(resp) == 2)
         
 
 if __name__ == '__main__':

--- a/tests/test_video_methods.py
+++ b/tests/test_video_methods.py
@@ -3,6 +3,7 @@ import os
 sys.path.append('../youtube-data-api/youtube_api')
 import unittest
 import requests
+import datetime
 
 from youtube_api import YoutubeDataApi
 
@@ -12,4 +13,28 @@ class TestVideo(unittest.TestCase):
     def setUpClass(cls):
         cls.key = os.environ.get('YT_KEY')
         cls.yt = YoutubeDataApi(cls.key)
-        cls.video_id = ''
+        cls.video_id = 'RdjRMDADpcg'
+        cls.channel_id = 'UC8-Th83bH_thdKZDJCrn88g'
+        cls.vid_publish = datetime.datetime(2018, 11, 28, 10, 0, 3)
+        cls.search_term = 'John Oliver'
+        
+    #written by Megan Brown on 11/30/2018
+    def test_video_metadata_valid(self):
+        resp = self.yt.get_video_metadata(self.video_id)
+        
+        self.assertEqual(resp['video_id'], self.video_id)
+        self.assertEqual(resp['channel_id'], self.channel_id)
+        self.assertEqual(resp['video_publish_date'], self.vid_publish)
+        
+    def test_search_for_video_method(self):
+        resp = self.yt.search(self.search_term)
+        
+        for item in resp:
+            self.assertTrue('video_id' in list(item.keys()))
+            self.assertTrue('video_title' in list(item.keys()))
+            self.assertTrue('channel_title' in list(item.keys()))
+
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_methods.py
+++ b/tests/test_video_methods.py
@@ -4,6 +4,7 @@ sys.path.append('../youtube-data-api/youtube_api')
 import unittest
 import requests
 import datetime
+from collections import OrderedDict
 
 from youtube_api import YoutubeDataApi
 
@@ -54,6 +55,11 @@ class TestVideo(unittest.TestCase):
         
         resp = self.yt.get_video_metadata(invalid_list_of_videos)
         self.assertTrue(len(resp) == 2)
+        
+    def test_video_metadata_invalid_string(self):
+        resp = self.yt.get_video_metadata('xx')
+        
+        self.assertEqual(resp, [OrderedDict()])
         
 
 if __name__ == '__main__':


### PR DESCRIPTION
adding tests for video methods including:
`test_video_metadata_valid`: tests a valid video input for proper metadata results
`def test_search_for_video_method`: tests search function for results of the proper format
`def test_video_metadata_with_list_input`: tests video metadata for list inputs with all valid results
`def test_video_metadata_with_invalid_list`: tests video metadata with a list that includes both valid and invalid results
`def test_video_metadata_invalid_string`: tests video metadata results for a single input of an invalid string
        