### PR TITLE
Extended YouTube video ID extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pandas
 pytube
 requests
+tldextract
 beautifulsoup4
 Cython

--- a/youtube_api/youtube_api_utils.py
+++ b/youtube_api/youtube_api_utils.py
@@ -8,6 +8,9 @@ from bs4 import BeautifulSoup, Comment
 import re
 import signal
 
+from urllib.parse import urlparse
+from urllib.parse import parse_qs
+
 '''
 This contains utilities used by other functions in the YoutubeDataApi class, as well as a few convenience functions for data analysis.
 '''


### PR DESCRIPTION
I added support for attribution_link forms of YouTube links and embed links to the strip_video_id_from_url() function. I also fixed a bug in the earlier version around a missing import for urllib