### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - 3.6
+- 3.7
+- 3.8
 sudo: false
 script: make test
 install: pip install -r requirements.txt

--- a/youtube_api/parsers.py
+++ b/youtube_api/parsers.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import datetime
+
 if sys.version_info[0] == 2:
     from collections import OrderedDict, Iterable
 else:

--- a/youtube_api/parsers.py
+++ b/youtube_api/parsers.py
@@ -1,11 +1,12 @@
 import json
 import sys
 import datetime
+from collections import OrderedDict
 
 if sys.version_info[0] == 2:
-    from collections import OrderedDict, Iterable
+    from collections import Iterable
 else:
-    from collections.abc import OrderedDict, Iterable
+    from collections.abc import Iterable
 
 from youtube_api.youtube_api_utils import parse_yt_datetime
 

--- a/youtube_api/parsers.py
+++ b/youtube_api/parsers.py
@@ -1,6 +1,10 @@
 import json
+import sys
 import datetime
-from collections import OrderedDict, Iterable
+if sys.version_info[0] == 2:
+    from collections import OrderedDict, Iterable
+else:
+    from collections.abc import OrderedDict, Iterable
 
 from youtube_api.youtube_api_utils import parse_yt_datetime
 


### PR DESCRIPTION
Fixes the following error:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import OrderedDict, Iterable
```