### PR TITLE
correct python error on 32 bits OS

### DIFF
--- a/youtube_api/youtube_api.py
+++ b/youtube_api/youtube_api.py
@@ -577,7 +577,7 @@ class YouTubeDataAPI:
     def search(self, q=None, channel_id=None,
                max_results=5, order_by="relevance", next_page_token=None,
                published_after=datetime.datetime.timestamp(datetime.datetime(2000,1,1)),
-               published_before=datetime.datetime.timestamp(datetime.datetime(3000,1,1)),
+               published_before=datetime.datetime.timestamp(datetime.datetime(2038,1,1)),
                location=None, location_radius='1km', region_code=None,
                safe_search=None, relevance_language=None, event_type=None,
                topic_id=None, video_duration=None, search_type="video",


### PR DESCRIPTION
Hello,

Using this awesome library on 32 bits OS (like raspbian) leads to a bug because 1st January 3000 is after end of unix time (19. January 2038). This patch correct the bug by setting a date before the end of unix time (2038)

Jean-Baptiste
