### PR TITLE
Added get_all_threads for retrieval of all comment threads 

### DIFF
--- a/youtube_api/parsers.py
+++ b/youtube_api/parsers.py
@@ -72,7 +72,9 @@ def parse_video_metadata(item):
         "video_dislike_count" : item["statistics"].get("dislikeCount"),
         "video_thumbnail" : item["snippet"]["thumbnails"]["high"]["url"],
         "video_tags" :  video_tags,
-        "collection_date" : datetime.datetime.now()
+        "collection_date" : datetime.datetime.now(),
+        "default_langage": item["snippet"].get("defaultLanguage"),
+        "audio_language": item["snippet"].get("defaultAudioLanguage")
     }
 
     return video_meta

--- a/youtube_api/youtube_api_utils.py
+++ b/youtube_api/youtube_api_utils.py
@@ -59,10 +59,12 @@ def parse_yt_datetime(date_str):
     if date_str:
         try:
             date = datetime.datetime.strptime(date_str,"%Y-%m-%dT%H:%M:%S.%fZ")
+            date = date.replace(tzinfo = datetime.timezone.utc)
             date = datetime.datetime.timestamp(date)
         except:
             try:
                 date = datetime.datetime.strptime(date_str,"%Y-%m-%dT%H:%M:%SZ")
+                date = date.replace(tzinfo = datetime.timezone.utc)
                 date = datetime.datetime.timestamp(date)
             except:
                 pass


### PR DESCRIPTION
Added get_all_threads for retrieval of all comment threads associated with a particular channel.

This implements the "list (all threads related to channel ID)" use case described in the YouTube Data API Reference documentation [here](https://developers.google.com/youtube/v3/docs/commentThreads/list): 

_This example retrieves all comment threads associated with a particular channel. The response could include comments about the channel or about the channel's videos. The request's allThreadsRelatedToChannelId parameter identifies the channel._

