### PR TITLE
stop the infinite request if items is an empty list

### DIFF
--- a/youtube_api/youtube_api.py
+++ b/youtube_api/youtube_api.py
@@ -325,6 +325,8 @@ class YouTubeDataAPI:
                     next_page_token = response_json.get('nextPageToken')
                 else:
                     break
+            else:
+                return None
 
         return playlists
 


### PR DESCRIPTION
tested.
If the channel has many videos but no playlists, 
the original function will infinitely send the request since the loop never break.